### PR TITLE
Reduce min cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.21)
 project(BallGameTheGame)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
This reduces the minimum cmake version to below the current stable release of cmake on APT, allowing it to be compiled on systems using APT installs of cmake.

This is important because APT is the default package manager for a lot of different operating systems.

In addition, generally, you should only require the minimum that is needed for the project to successfully build. It is worth noting that the value I changed it to (3.21) is not necessarily as low as it can go but simply one below the latest APT package version (3.22).